### PR TITLE
define scrollHold propType

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -7,6 +7,7 @@ class ReactSwipe extends Component {
             startSlide: PropTypes.number,
             speed: PropTypes.number,
             auto: PropTypes.number,
+            scrollHold: PropTypes.number,
             continuous: PropTypes.bool,
             disableScroll: PropTypes.bool,
             stopPropagation: PropTypes.bool,


### PR DESCRIPTION
#1 看了源码发现可以通过 `swipeOptions` 传递给 `silk-swipe` 组件。 

改动：在 `PropTypes.shape()` 添加 `scrollHold: PropTypes.number,` 属性